### PR TITLE
Update tests dir validation logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,4 @@ jobs:
         pip install '.[test]'
     - name: Run tests
       run: |
-        [ -d tests ] && pytest || echo "Tests directory not found"
+        if [ -d tests ]; then pytest; else echo "Tests directory not found"; fi


### PR DESCRIPTION
Found this while developing a package using this repo. My PR tests were passing, but the publish failed due to testing failures. 

What I saw was that because I had some tests fail, the step was returning the echo "Tests directory not found", and the step was successful. 

```
...
=========================== short test summary info ============================
ERROR tests/test_...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.19s ===============================
Tests directory not found
```

https://github.com/glasnt/janky/commits/showcase/ shows the issue and resolution I experienced. 

Current version causes the right side to execute if either left side fails (including pytest failing). Suggested fix turns the check into a full conditional. 

(Submitted in a GitHub-web based editing, as making a full fork to then submit a patch ran the initial Workflow and the PR had a whole lot more files than expected 😅 )