### PR TITLE
Update link to the correct demo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once created, your new repository will execute a GitHub Actions workflow that us
 
 You can see an example of a repository generated using this template here:
 
-- https://github.com/simonw/python-lib-template-repository-demo
+- [https://github.com/simonw/python-lib-template-demo](https://github.com/simonw/python-lib-template-demo)
 
 ## GitHub Actions setup by this repository
 


### PR DESCRIPTION
The link currently leads to a 404 page. Set correct link to demo repo.

Btw.: Thanks very much for making this template available! 👍